### PR TITLE
Fix history reconstruction and reinstatement and add tests

### DIFF
--- a/modules/infra/src/brainard/infra/store/queries.cljc
+++ b/modules/infra/src/brainard/infra/store/queries.cljc
@@ -72,7 +72,7 @@
                         (some? to) (assoc attr to)
                         added (update attr (fnil into #{}) added)
                         removed (update attr (partial apply disj) removed)))
-                    (dissoc prev :attachments/changes))
+                    (dissoc prev :attachments/changes :attachments/previous))
          (handle-attachment-changes changes))))
 
 (defn ^:private history-reducer [versions {:notes/keys [changes history-id saved-at]}]

--- a/modules/infra/src/brainard/infra/store/queries.cljc
+++ b/modules/infra/src/brainard/infra/store/queries.cljc
@@ -24,56 +24,127 @@
   (some-> (get-in db [:toasts/toasts toast-id])
           (assoc :id toast-id)))
 
-(defn ^:private handle-attachment-changes [{{:keys [added removed]} :notes/attachments :as change} version]
-  (let [prev-attachments (:attachments/previous version)
-        next-attachments (-> {}
-                             (into (filter (comp int? key)) (:attachments/changes change))
-                             (update-vals (partial into
-                                                   {}
-                                                   (keep (fn [[k {:keys [to]}]]
-                                                           (when to
-                                                             [k to]))))))
-        attachment-changes (into {}
-                                 (keep (fn [id]
-                                         (let [prev (or (get-in prev-attachments [id :attachments/name])
-                                                        (get-in change [:attachments/changes id :attachments/name :from]))
-                                               next (or (get-in next-attachments [id :attachments/name])
-                                                        (get-in version [:attachments/state id :attachments/name]))]
-                                           (when-let [update (cond
-                                                               (contains? removed id)
-                                                               {:removed (or next prev)}
-
-                                                               (contains? added id)
-                                                               {:added next}
-
-                                                               (and prev (not= prev next))
-                                                               {:from prev
-                                                                :to   next})]
-                                             [id update]))))
-                                 (into #{}
-                                       (concat (keys (:attachments/state version))
-                                               (keys (:attachments/changes version))
-                                               (keys next-attachments)
-                                               added
-                                               removed)))]
+(defn ^:private handle-changes [change type change-fn version]
+  (let [type (name type)
+        note-k (keyword "notes" type)
+        prev-k (keyword type "previous")
+        changes-k (keyword type "changes")
+        state-k (keyword type "state")
+        {:keys [added removed]} (note-k change)
+        prev-items (state-k version)
+        next-items (-> {}
+                       (into (filter (comp int? key)) (changes-k change))
+                       (update-vals (partial into
+                                            {}
+                                            (keep (fn [[k {:keys [to]}]]
+                                                    (when (some? to)
+                                                      [k to]))))))
+        item-changes (into {}
+                           (keep (partial change-fn prev-items next-items))
+                           (into #{}
+                                 (concat (keys (state-k version))
+                                         (keys (changes-k version))
+                                         (keys next-items)
+                                         added
+                                         removed)))]
     (-> version
-        (update :attachments/state maps/deep-merge next-attachments)
-        (assoc :attachments/previous (:attachments/state version)
-               :attachments/changes attachment-changes))))
+        (update state-k maps/deep-merge next-items)
+        (assoc prev-k prev-items changes-k item-changes))))
+
+(defn ^:private extract-diffs [prev-items next-items change version id ns ks]
+  (let [change-k (keyword (name ns) "changes")
+        state-k (keyword (name ns) "state")]
+    (into {}
+          (mapcat (fn [k]
+                    (let [el-k (keyword (name ns) (name k))
+                          prev-k (keyword (str "prev-" (name k)))
+                          next-k (keyword (str "next-" (name k)))
+                          prev (get-in prev-items [id el-k])
+                          prev (if (some? prev)
+                                 prev
+                                 (get-in change [change-k id el-k :from]))
+                          next (get-in next-items [id el-k])
+                          next (if (some? next)
+                                 next
+                                 (get-in version [state-k id el-k]))]
+                      [[prev-k prev] [next-k next]])))
+          ks)))
+
+(defn ^:private handle-attachment-changes [{{:keys [added removed]} :notes/attachments :as change} version]
+  (->> version
+       (handle-changes change
+                       :attachments
+                       (fn [prev-attachments next-attachments id]
+                         (let [{:keys [prev-name next-name]} (extract-diffs prev-attachments
+                                                                            next-attachments
+                                                                            change
+                                                                            version
+                                                                            id
+                                                                            :attachments
+                                                                            [:name])]
+                           (when-let [update (cond
+                                               (contains? removed id)
+                                               {:removed (or next-name prev-name)}
+
+                                               (contains? added id)
+                                               {:added next-name}
+
+                                               (and prev-name (not= prev-name next-name))
+                                               {:from prev-name
+                                                :to   next-name})]
+                             [id update]))))))
+
+(defn ^:private handle-todo-changes [{{:keys [added removed]} :notes/todos :as change} version]
+  (->> version
+       (handle-changes change
+                       :todos
+                       (fn [prev-todos next-todos id]
+                         (let [{:keys [prev-completed? next-completed? prev-text next-text]}
+                               (extract-diffs prev-todos
+                                              next-todos
+                                              change
+                                              version
+                                              id
+                                              :todos
+                                              [:text :completed?])]
+                           (when-let [update (cond
+                                               (contains? removed id)
+                                               {:removed (or next-text prev-text)}
+
+                                               (contains? added id)
+                                               {:added next-text
+                                                :done? (boolean next-completed?)}
+
+                                               (and prev-text (not= prev-text next-text))
+                                               (cond-> {:from prev-text
+                                                        :to   next-text}
+                                                 (and (or prev-completed? next-completed?)
+                                                      (not= prev-completed? next-completed?))
+                                                 (assoc :done? next-completed?))
+
+                                               (and (some? next-completed?)
+                                                    (not= prev-completed? next-completed?))
+                                               {:todo  (or next-text prev-text)
+                                                :done? next-completed?})]
+                             [id update]))))))
 
 (defn ^:private reconstruct [prev changes]
   (let [changes (-> changes
                     (update-in [:notes/attachments :added] set)
                     (update-in [:notes/attachments :removed] set)
-                    (update :attachments/changes merge {}))]
+                    (update-in [:notes/todos :added] set)
+                    (update-in [:notes/todos :removed] set)
+                    (update :attachments/changes merge {})
+                    (update :todos/changes merge {}))]
     (->> changes
          (reduce-kv (fn [version attr {:keys [added removed to]}]
                       (cond-> version
                         (some? to) (assoc attr to)
                         added (update attr (fnil into #{}) added)
                         removed (update attr (partial apply disj) removed)))
-                    (dissoc prev :attachments/changes :attachments/previous))
-         (handle-attachment-changes changes))))
+                    (dissoc prev :attachments/changes :todos/changes))
+         (handle-attachment-changes changes)
+         (handle-todo-changes changes))))
 
 (defn ^:private history-reducer [versions {:notes/keys [changes history-id saved-at]}]
   (let [[_ prev] (peek versions)

--- a/modules/infra/src/brainard/infra/store/queries.cljc
+++ b/modules/infra/src/brainard/infra/store/queries.cljc
@@ -35,10 +35,10 @@
         next-items (-> {}
                        (into (filter (comp int? key)) (changes-k change))
                        (update-vals (partial into
-                                            {}
-                                            (keep (fn [[k {:keys [to]}]]
-                                                    (when (some? to)
-                                                      [k to]))))))
+                                             {}
+                                             (keep (fn [[k {:keys [to]}]]
+                                                     (when (some? to)
+                                                       [k to]))))))
         item-changes (into {}
                            (keep (partial change-fn prev-items next-items))
                            (into #{}

--- a/modules/infra/src/brainard/infra/views/pages/note/history.cljc
+++ b/modules/infra/src/brainard/infra/views/pages/note/history.cljc
@@ -15,6 +15,12 @@
     [note-comp/attachment-list {:label? true
                                 :value  attachments}]))
 
+(defn ^:private todo-list [note]
+  (when-let [todos (not-empty (:notes/todos note))]
+    [note-comp/todo-list {:label? true
+                          :disabled true
+                          :value  todos}]))
+
 (defmulti ^:private ^{:arglists '([label changes])} history-change
           (fn [label _]
             label))
@@ -132,6 +138,7 @@
     [:h1 [:strong (:notes/context note)]]]
    [comp/markdown (:notes/body note)]
    [attachment-list note]
+   [todo-list note]
    [note-comp/tag-list note]
    (when-not last?
      [:div
@@ -155,7 +162,9 @@
            :let [note (get reconstruction history-id)
                  attachment-changes (:attachments/changes note)
                  todo-changes (:todos/changes note)
-                 note (update note :notes/attachments (partial map (:attachments/state note)))
+                 note (-> note
+                          (update :notes/attachments (partial map (:attachments/state note)))
+                          (update :notes/todos (partial map (:todos/state note))))
                  history-modal [::view {:last?            (= idx last-idx)
                                         :note             note
                                         :prev-tags        prev-tags

--- a/modules/infra/src/brainard/infra/views/pages/note/history.cljc
+++ b/modules/infra/src/brainard/infra/views/pages/note/history.cljc
@@ -143,7 +143,7 @@
    (when-not last?
      [:div
       [comp/plain-button {:*:store  *:store
-                          :class    ["is-small" "is-info"]
+                          :class    ["is-small" "is-info" "note__history-reinstate"]
                           :commands [[:modals/remove! modal-id]
                                      [::res/submit! [::note.act/notes#reinstate modal-id] params]]}
        "reinstate"]])])
@@ -152,11 +152,15 @@
   (let [last-idx (dec (count entries))
         last-history-id (:notes/history-id (last entries))
         last-entry (get reconstruction last-history-id)
-        prev-tags (:notes/tags last-entry)
         prev-attachments (->> last-entry
                               :notes/attachments
                               (map (:attachments/state last-entry))
-                              set)]
+                              set)
+        prev-tags (:notes/tags last-entry)
+        prev-todos (->> last-entry
+                        :notes/todos
+                        (map (:todos/state last-entry))
+                        set)]
     [:ul.note-history
      (for [[idx {:notes/keys [changes history-id saved-at]}] (map-indexed vector entries)
            :let [note (get reconstruction history-id)
@@ -167,8 +171,9 @@
                           (update :notes/todos (partial map (:todos/state note))))
                  history-modal [::view {:last?            (= idx last-idx)
                                         :note             note
+                                        :prev-attachments prev-attachments
                                         :prev-tags        prev-tags
-                                        :prev-attachments prev-attachments}]
+                                        :prev-todos       prev-todos}]
                  change-list (for [[k label] [[:notes/context "Topic"]
                                               [:notes/pinned? "Pin"]
                                               [:notes/body "Body"]

--- a/modules/infra/src/brainard/infra/views/pages/note/history.cljc
+++ b/modules/infra/src/brainard/infra/views/pages/note/history.cljc
@@ -78,6 +78,46 @@
           [:span.space--left.truncate.blue {:style {:max-width "50%"}}
            (str to)]])])]])
 
+(defmethod history-change "Todos"
+  [label changes]
+  [:div
+   [:span.layout--row.purple label]
+   [:ul
+    (for [[id {:keys [added done? from removed to todo]}] changes]
+      ^{:key id}
+      [:li.layout--row.layout--indent
+       (cond
+         added
+         [:<>
+          [:em.space--left "added"]
+          [:span.space--left.truncate.blue added]]
+
+         removed
+         [:<>
+          [:em.space--left "removed"]
+          [:span.space--left.truncate.orange removed]]
+
+         (and from to)
+         [:<>
+          [:em.space--left "changed"]
+          [:span.space--left.truncate.orange {:style {:max-width "50%"}}
+           (str from)]
+          [:em.space--left "to"]
+          [:span.space--left.truncate.blue {:style {:max-width "50%"}}
+           (str to)]]
+
+         (some? done?)
+         [:span.space--left.truncate.purple {:style {:max-width "50%"}}
+          (str (or todo added to))])
+       (when (some? done?)
+         [:<>
+          [:em.space--left "marked"]
+          (if done?
+            [:span.space--left.truncate.green {:style {:max-width "50%"}}
+             "complete"]
+            [:span.space--left.truncate.yellow {:style {:max-width "50%"}}
+             "incomplete"])])])]])
+
 (defmethod icomp/modal-header ::view
   [_ {:notes/keys [saved-at]}]
   (dates/->str saved-at))
@@ -114,6 +154,7 @@
      (for [[idx {:notes/keys [changes history-id saved-at]}] (map-indexed vector entries)
            :let [note (get reconstruction history-id)
                  attachment-changes (:attachments/changes note)
+                 todo-changes (:todos/changes note)
                  note (update note :notes/attachments (partial map (:attachments/state note)))
                  history-modal [::view {:last?            (= idx last-idx)
                                         :note             note
@@ -123,7 +164,8 @@
                                               [:notes/pinned? "Pin"]
                                               [:notes/body "Body"]
                                               [:notes/tags "Tags"]
-                                              [(constantly (not-empty attachment-changes)) "Attachments"]]
+                                              [(constantly (not-empty attachment-changes)) "Attachments"]
+                                              [(constantly (not-empty todo-changes)) "Todos"]]
                                    :let [change (k changes)]
                                    :when change]
                                [history-change label change])]

--- a/modules/infra/src/brainard/infra/views/pages/note/history.cljc
+++ b/modules/infra/src/brainard/infra/views/pages/note/history.cljc
@@ -134,7 +134,7 @@
          [:div
           [:span.layout--space-after.green (dates/->str saved-at)]]
          [comp/plain-button {:*:store  *:store
-                             :class    ["is-small" "is-info"]
+                             :class    ["is-small" "is-info" "note__history-show"]
                              :commands [[:modals/create! history-modal]]}
           "show"]]
         (into [:<>] change-list)])]))

--- a/modules/infra/src/brainard/notes/infra/db.clj
+++ b/modules/infra/src/brainard/notes/infra/db.clj
@@ -72,73 +72,89 @@
        (sort-by second)
        (reduce-history [])))
 
-(defn ^:private prep-attachment-history [_ results]
+(defn ^:private prep-child-history [changes-k results]
   (->> results
        (sort-by second)
        (group-by first)
        (mapcat (fn [[k vals]]
-                 (reduce-history [:attachments/changes k] vals)))
+                 (reduce-history [changes-k k] vals)))
        (sort-by :notes/history-id)))
 
 (defn ^:private combine-history
-  ([note-history attachment-history]
-   (combine-history note-history attachment-history []))
-  ([[note-hist :as note-history] [att-hist :as attachment-history] combined-history]
+  ([note-history sub-history sub-k]
+   (combine-history note-history sub-history sub-k []))
+  ([[note-hist :as note-history] [sub-hist :as sub-history] sub-k combined-history]
    (cond
-     (empty? attachment-history)
+     (empty? sub-history)
      (into combined-history note-history)
 
      (empty? note-history)
-     (into combined-history attachment-history)
+     (into combined-history sub-history)
 
-     (= (:notes/history-id note-hist) (:notes/history-id att-hist))
+     (= (:notes/history-id note-hist) (:notes/history-id sub-hist))
      (recur (update-in note-history
                        [0 :notes/changes]
                        maps/deep-merge
-                       (:notes/changes att-hist))
-            (rest attachment-history)
+                       (:notes/changes sub-hist))
+            (rest sub-history)
+            sub-k
             combined-history)
 
-     (and (> (:notes/history-id note-hist) (:notes/history-id att-hist))
-          (-> note-hist :notes/changes :notes/attachments :added))
+     (and (> (:notes/history-id note-hist) (:notes/history-id sub-hist))
+          (-> note-hist :notes/changes sub-k :added))
      (recur (update-in note-history
                        [0 :notes/changes]
                        maps/deep-merge
-                       (:notes/changes att-hist))
-            (rest attachment-history)
+                       (:notes/changes sub-hist))
+            (rest sub-history)
+            sub-k
             combined-history)
 
-     (> (:notes/history-id note-hist) (:notes/history-id att-hist))
+     (> (:notes/history-id note-hist) (:notes/history-id sub-hist))
      (recur note-history
-            (rest attachment-history)
-            (conj combined-history att-hist))
+            (rest sub-history)
+            sub-k
+            (conj combined-history sub-hist))
 
      :else
      (recur (vec (rest note-history))
-            attachment-history
+            sub-history
+            sub-k
             (conj combined-history note-hist)))))
+
+(def ^:private child-query
+  '[:find ?e ?tx ?op ?attr ?val ?at ?card
+    :in $ [?e ...]
+    :where
+    [?e ?a ?val ?tx ?op]
+    [?tx :db/txInstant ?at]
+    [?a :db/ident ?attr]
+    [?a :db/cardinality ?c]
+    [?c :db/ident ?card]])
 
 (defn ^:private prep-history [db results]
   (when (seq results)
     (let [note-history (prep-note-history results)
-          attachment-ids (into #{}
-                               (keep (fn [[_ _ _ attr val]]
-                                       (when (= :notes/attachments attr)
-                                         val)))
-                               results)
+          ids (reduce (fn [ids [_ _ _ attr val]]
+                        (case attr
+                          :notes/attachments (update ids :attachment-ids conj val)
+                          :notes/todos (update ids :todo-ids conj val)
+                          ids))
+                      {:attachment-ids #{} :todo-ids #{}}
+                      results)
           attachment-history (ds/query db
-                                       {:query    '[:find ?e ?tx ?op ?attr ?val ?at ?card
-                                                    :in $ [?e ...]
-                                                    :where
-                                                    [?e ?a ?val ?tx ?op]
-                                                    [?tx :db/txInstant ?at]
-                                                    [?a :db/ident ?attr]
-                                                    [?a :db/cardinality ?c]
-                                                    [?c :db/ident ?card]]
-                                        :args     [attachment-ids]
+                                       {:query    child-query
+                                        :args     [(:attachment-ids ids)]
                                         :history? true
-                                        :post     prep-attachment-history})]
-      (combine-history note-history attachment-history))))
+                                        :post     #(prep-child-history :attachments/changes %2)})
+          todo-history (ds/query db
+                                 {:query    child-query
+                                  :args     [(:todo-ids ids)]
+                                  :history? true
+                                  :post     #(prep-child-history :todos/changes %2)})]
+      (-> note-history
+          (combine-history attachment-history :notes/attachments)
+          (combine-history todo-history :notes/todos)))))
 
 (defn ^:private clean-note [note]
   (-> note

--- a/modules/infra/src/brainard/notes/infra/db.clj
+++ b/modules/infra/src/brainard/notes/infra/db.clj
@@ -119,25 +119,26 @@
             (conj combined-history note-hist)))))
 
 (defn ^:private prep-history [db results]
-  (let [note-history (prep-note-history results)
-        attachment-ids (into #{}
-                             (keep (fn [[_ _ _ attr val]]
-                                     (when (= :notes/attachments attr)
-                                       val)))
-                             results)
-        attachment-history (ds/query db
-                                     {:query    '[:find ?e ?tx ?op ?attr ?val ?at ?card
-                                                  :in $ [?e ...]
-                                                  :where
-                                                  [?e ?a ?val ?tx ?op]
-                                                  [?tx :db/txInstant ?at]
-                                                  [?a :db/ident ?attr]
-                                                  [?a :db/cardinality ?c]
-                                                  [?c :db/ident ?card]]
-                                      :args     [attachment-ids]
-                                      :history? true
-                                      :post     prep-attachment-history})]
-    (combine-history note-history attachment-history)))
+  (when (seq results)
+    (let [note-history (prep-note-history results)
+          attachment-ids (into #{}
+                               (keep (fn [[_ _ _ attr val]]
+                                       (when (= :notes/attachments attr)
+                                         val)))
+                               results)
+          attachment-history (ds/query db
+                                       {:query    '[:find ?e ?tx ?op ?attr ?val ?at ?card
+                                                    :in $ [?e ...]
+                                                    :where
+                                                    [?e ?a ?val ?tx ?op]
+                                                    [?tx :db/txInstant ?at]
+                                                    [?a :db/ident ?attr]
+                                                    [?a :db/cardinality ?c]
+                                                    [?c :db/ident ?card]]
+                                        :args     [attachment-ids]
+                                        :history? true
+                                        :post     prep-attachment-history})]
+      (combine-history note-history attachment-history))))
 
 (defn ^:private clean-note [note]
   (-> note

--- a/modules/infra/test/src/brainard/infra/store/queries_test.cljc
+++ b/modules/infra/test/src/brainard/infra/store/queries_test.cljc
@@ -15,18 +15,18 @@
 
 (deftest notes-history-reconstruction-test
   (testing "when the resource is not loaded"
-    (let [spec  [::specs/note#history (random-uuid)]
+    (let [spec [::specs/note#history (random-uuid)]
           store (defacto/create {} {})]
       (is (nil? (store/query store [:notes.history/?:reconstruction spec])))))
 
   (testing "when there are no history entries"
-    (let [spec  [::specs/note#history (random-uuid)]
+    (let [spec [::specs/note#history (random-uuid)]
           store (store-with-history spec [])]
       (is (= {} (store/query store [:notes.history/?:reconstruction spec])))))
 
   (testing "with a single history entry"
-    (let [h1    (random-uuid)
-          spec  [::specs/note#history (random-uuid)]
+    (let [h1 (random-uuid)
+          spec [::specs/note#history (random-uuid)]
           store (store-with-history spec [{:notes/history-id h1
                                            :notes/saved-at   #inst "2024-01-01"
                                            :notes/changes    {:notes/body    {:to "hello"}
@@ -39,21 +39,21 @@
 
   (testing "with multiple history entries"
     (let [[h1 h2 h3] (repeatedly random-uuid)
-          spec       [::specs/note#history (random-uuid)]
-          store      (store-with-history spec [{:notes/history-id h1
-                                                :notes/saved-at   #inst "2024-01-01"
-                                                :notes/changes    {:notes/body    {:to "v1"}
-                                                                   :notes/context {:to "ctx-a"}
-                                                                   :notes/tags    {:added #{:a :b :c}}}}
-                                               {:notes/history-id h2
-                                                :notes/saved-at   #inst "2024-01-02"
-                                                :notes/changes    {:notes/body {:to "v2"}
-                                                                   :notes/tags {:added   #{:d}
-                                                                                :removed #{:a}}}}
-                                               {:notes/history-id h3
-                                                :notes/saved-at   #inst "2024-01-03"
-                                                :notes/changes    {:notes/body {:to "v3"}}}])
-          result     (store/query store [:notes.history/?:reconstruction spec])]
+          spec [::specs/note#history (random-uuid)]
+          store (store-with-history spec [{:notes/history-id h1
+                                           :notes/saved-at   #inst "2024-01-01"
+                                           :notes/changes    {:notes/body    {:to "v1"}
+                                                              :notes/context {:to "ctx-a"}
+                                                              :notes/tags    {:added #{:a :b :c}}}}
+                                          {:notes/history-id h2
+                                           :notes/saved-at   #inst "2024-01-02"
+                                           :notes/changes    {:notes/body {:to "v2"}
+                                                              :notes/tags {:added   #{:d}
+                                                                           :removed #{:a}}}}
+                                          {:notes/history-id h3
+                                           :notes/saved-at   #inst "2024-01-03"
+                                           :notes/changes    {:notes/body {:to "v3"}}}])
+          result (store/query store [:notes.history/?:reconstruction spec])]
       (testing "v1 has the initial state"
         (is (= "v1" (get-in result [h1 :notes/body])))
         (is (= #{:a :b :c} (get-in result [h1 :notes/tags]))))
@@ -69,22 +69,22 @@
         (is (= "ctx-a" (get-in result [h3 :notes/context]))))))
 
   (testing "with attachment history"
-    (let [att-ref      123
-          [h1 h2 h3]  (repeatedly random-uuid)
-          spec         [::specs/note#history (random-uuid)]
-          store        (store-with-history spec [{:notes/history-id h1
-                                                  :notes/saved-at   #inst "2024-01-01"
-                                                  :notes/changes    {:notes/attachments   {:added #{att-ref}}
-                                                                     :attachments/changes {att-ref {:attachments/name {:to "original.txt"}}}}}
-                                                 {:notes/history-id h2
-                                                  :notes/saved-at   #inst "2024-01-02"
-                                                  :notes/changes    {:attachments/changes {att-ref {:attachments/name {:from "original.txt"
-                                                                                                                       :to   "renamed.txt"}}}}}
-                                                 {:notes/history-id h3
-                                                  :notes/saved-at   #inst "2024-01-03"
-                                                  :notes/changes    {:notes/attachments   {:removed #{att-ref}}
-                                                                     :attachments/changes {att-ref {:attachments/name {:from "renamed.txt"}}}}}])
-          result       (store/query store [:notes.history/?:reconstruction spec])]
+    (let [att-ref 123
+          [h1 h2 h3] (repeatedly random-uuid)
+          spec [::specs/note#history (random-uuid)]
+          store (store-with-history spec [{:notes/history-id h1
+                                           :notes/saved-at   #inst "2024-01-01"
+                                           :notes/changes    {:notes/attachments   {:added #{att-ref}}
+                                                              :attachments/changes {att-ref {:attachments/name {:to "original.txt"}}}}}
+                                          {:notes/history-id h2
+                                           :notes/saved-at   #inst "2024-01-02"
+                                           :notes/changes    {:attachments/changes {att-ref {:attachments/name {:from "original.txt"
+                                                                                                                :to   "renamed.txt"}}}}}
+                                          {:notes/history-id h3
+                                           :notes/saved-at   #inst "2024-01-03"
+                                           :notes/changes    {:notes/attachments   {:removed #{att-ref}}
+                                                              :attachments/changes {att-ref {:attachments/name {:from "renamed.txt"}}}}}])
+          result (store/query store [:notes.history/?:reconstruction spec])]
       (testing "v1 shows the attachment added"
         (is (contains? (get-in result [h1 :notes/attachments]) att-ref))
         (is (= {:added "original.txt"} (get-in result [h1 :attachments/changes att-ref]))))

--- a/test/resources/fixtures/seed/history.edn
+++ b/test/resources/fixtures/seed/history.edn
@@ -1,14 +1,14 @@
-{1 [{:notes/id          #uuid "c5bb659a-0bdf-431c-a145-810455441220"
-     :notes/context     "Some context"
-     :notes/body        "Some body"
-     :notes/tags        #{:foo :bar :baz/quux}
-     :notes/pinned?     true
-     :notes/todos       #{{:todos/id         #uuid "0b1c3571-c413-41c3-ac04-d6713b3cdbc6"
-                           :todos/text       "Do a thing"
-                           :todos/completed? false}}}]
+{1 [{:notes/id      #uuid "c5bb659a-0bdf-431c-a145-810455441220"
+     :notes/context "Some context"
+     :notes/body    "Some body"
+     :notes/tags    #{:foo :bar :baz/quux}
+     :notes/pinned? true
+     :notes/todos   #{{:todos/id         #uuid "0b1c3571-c413-41c3-ac04-d6713b3cdbc6"
+                       :todos/text       "Do a thing"
+                       :todos/completed? false}}}]
  2 [[:db/retract [:notes/id #uuid "c5bb659a-0bdf-431c-a145-810455441220"] :notes/tags :bar]
-    {:notes/id   #uuid "c5bb659a-0bdf-431c-a145-810455441220"
-     :notes/body "Some edited body goes here"
+    {:notes/id          #uuid "c5bb659a-0bdf-431c-a145-810455441220"
+     :notes/body        "Some edited body goes here"
      :notes/attachments #{{:attachments/id           #uuid "2006bd32-941e-49e4-bf3a-adcd9e37d1da"
                            :attachments/content-type "application/pdf"
                            :attachments/filename     "some-pdf.pdf"
@@ -28,6 +28,7 @@
  4 [{:notes/id      #uuid "c5bb659a-0bdf-431c-a145-810455441220"
      :notes/pinned? false
      :notes/todos   #{{:todos/id         #uuid "0b1c3571-c413-41c3-ac04-d6713b3cdbc6"
+                       :todos/text       "Did a thing"
                        :todos/completed? true}}}]
  5 [{:notes/id          #uuid "c5bb659a-0bdf-431c-a145-810455441220"
      :notes/attachments #{{:attachments/id   #uuid "addb9e9a-9578-4069-81c1-2472741ead1e"
@@ -44,4 +45,6 @@
      :notes/context "Some new context"
      :notes/body    "Some completely different body"
      :notes/tags    #{:other/tag}
-     :notes/pinned? false}]}
+     :notes/pinned? false
+     :notes/todos   #{{:todos/id   #uuid "b2b0d144-6be1-4e7f-bb53-d849424cd828"
+                       :todos/text "Do some third thing still"}}}]}

--- a/test/resources/fixtures/seed/history.edn
+++ b/test/resources/fixtures/seed/history.edn
@@ -1,0 +1,47 @@
+{1 [{:notes/id          #uuid "c5bb659a-0bdf-431c-a145-810455441220"
+     :notes/context     "Some context"
+     :notes/body        "Some body"
+     :notes/tags        #{:foo :bar :baz/quux}
+     :notes/pinned?     true
+     :notes/todos       #{{:todos/id         #uuid "0b1c3571-c413-41c3-ac04-d6713b3cdbc6"
+                           :todos/text       "Do a thing"
+                           :todos/completed? false}}}]
+ 2 [[:db/retract [:notes/id #uuid "c5bb659a-0bdf-431c-a145-810455441220"] :notes/tags :bar]
+    {:notes/id   #uuid "c5bb659a-0bdf-431c-a145-810455441220"
+     :notes/body "Some edited body goes here"
+     :notes/attachments #{{:attachments/id           #uuid "2006bd32-941e-49e4-bf3a-adcd9e37d1da"
+                           :attachments/content-type "application/pdf"
+                           :attachments/filename     "some-pdf.pdf"
+                           :attachments/name         "some-pdf.pdf"}
+                          {:attachments/id           #uuid "55cfe069-78ca-40a6-af9a-f5f033e446df"
+                           :attachments/content-type "plain/text"
+                           :attachments/filename     "sample.txt"
+                           :attachments/name         "sample.txt"}}}]
+ 3 [{:notes/id          #uuid "c5bb659a-0bdf-431c-a145-810455441220"
+     :notes/attachments #{{:attachments/id           #uuid "addb9e9a-9578-4069-81c1-2472741ead1e"
+                           :attachments/content-type "image/jpeg"
+                           :attachments/filename     "image.jpg"
+                           :attachments/name         "image.jpg"}}
+     :notes/todos       #{{:todos/id         #uuid "7ebfc421-7ec4-439b-b035-09fc614b6975"
+                           :todos/text       "Do another thing"
+                           :todos/completed? false}}}]
+ 4 [{:notes/id      #uuid "c5bb659a-0bdf-431c-a145-810455441220"
+     :notes/pinned? false
+     :notes/todos   #{{:todos/id         #uuid "0b1c3571-c413-41c3-ac04-d6713b3cdbc6"
+                       :todos/completed? true}}}]
+ 5 [{:notes/id          #uuid "c5bb659a-0bdf-431c-a145-810455441220"
+     :notes/attachments #{{:attachments/id   #uuid "addb9e9a-9578-4069-81c1-2472741ead1e"
+                           :attachments/name "some other name"}}
+     :notes/todos       #{{:todos/id         #uuid "7ebfc421-7ec4-439b-b035-09fc614b6975"
+                           :todos/completed? true}
+                          {:todos/id         #uuid "b2b0d144-6be1-4e7f-bb53-d849424cd828"
+                           :todos/text       "Do some third thing"
+                           :todos/completed? false}}}]
+ 6 [[:db/retractEntity [:attachments/id #uuid "2006bd32-941e-49e4-bf3a-adcd9e37d1da"]]
+    [:db/retractEntity [:todos/id #uuid "7ebfc421-7ec4-439b-b035-09fc614b6975"]]
+    [:db/retract [:notes/id #uuid "c5bb659a-0bdf-431c-a145-810455441220"] :notes/tags :baz/quux]
+    {:notes/id      #uuid "c5bb659a-0bdf-431c-a145-810455441220"
+     :notes/context "Some new context"
+     :notes/body    "Some completely different body"
+     :notes/tags    #{:other/tag}
+     :notes/pinned? false}]}

--- a/test/src/brainard/test/integration/notes_test.clj
+++ b/test/src/brainard/test/integration/notes_test.clj
@@ -296,7 +296,13 @@
                              :notes/attachments   {:removed #{attachment-ref}}}
                             {:notes/pinned? {:from true
                                              :to   false}}]
-                           (map :notes/changes history)))))))))))))
+                           (map :notes/changes history))))))))))
+
+      (testing "and when querying the history for an unknown note"
+        (let [history (storage/query storage {::storage/type ::api.notes/get-note-history
+                                              :notes/id      (random-uuid)})]
+          (testing "returns no data"
+            (is (nil? history))))))))
 
 (deftest get-tags-test
   (tsys/with-system [{::b/keys [notes-api]} nil]

--- a/test/src/brainard/test/ui/notes/history_test.clj
+++ b/test/src/brainard/test/ui/notes/history_test.clj
@@ -7,9 +7,6 @@
     [clojure.test :refer [deftest is testing]]
     [etaoin.api :as eta]))
 
-;; fix todos
-;; 404 on /history for unknown note
-
 (deftest view-history-test
   (ui-sys/with-system [driver base-url {fix "history.edn"}]
     (let [note-id (-> fix first :notes/id)]
@@ -23,7 +20,7 @@
           (eta/screenshot driver "foo.png")
           (let [[ver-1 ver-2 ver-3 ver-4 ver-5 ver-6]
                 (for [li (eta/query-all driver {:css "ul.note-history > li"})]
-                  (-> (str "\t" (eta/get-element-text-el driver li))
+                  (-> (eta/get-element-text-el driver li)
                       (string/replace #"\s+" " ")))]
 
             (testing "displays version 1 changes"
@@ -63,7 +60,7 @@
                 (is (eta/has-text? driver {:css ".history__view h1"} "Some context"))
                 (is (eta/has-text? driver {:css ".history__view .content p"} "Some body"))
                 (is (not (eta/exists? driver {:xpath "//*[contains(@class,'history__view')]//label[text()='Attachments:']"})))
-                (is (not (eta/exists? driver {:css ".history__view ul.attachment-list li"})))
+                (is (not (eta/exists? driver {:css ".history__view ul.attachment-list"})))
                 (is (= #{:foo :bar :baz/quux}
                        (into #{}
                              (map (comp edn/read-string (partial eta/get-element-text-el driver)))

--- a/test/src/brainard/test/ui/notes/history_test.clj
+++ b/test/src/brainard/test/ui/notes/history_test.clj
@@ -7,6 +7,27 @@
     [clojure.test :refer [deftest is testing]]
     [etaoin.api :as eta]))
 
+(defn ^:private collect-attachments [driver css-prefix]
+  (into #{}
+        (map (partial eta/get-element-text-el driver))
+        (eta/query-all driver {:css (str css-prefix " ul.attachment-list li")})))
+
+(defn ^:private collect-todos [driver css-prefix]
+  (into {}
+        (map (fn [todo]
+               (let [txt (eta/get-element-text-el driver todo)
+                     chbox (eta/query-from-shadow-root-el driver
+                                                          todo
+                                                          {:css "input[type=checkbox]:disabled"})
+                     checked (eta/get-element-attr-el driver chbox "checked")]
+                 [txt (some? checked)])))
+        (eta/query-all driver {:css (str css-prefix " .todo-list .todo")})))
+
+(defn ^:private collect-tags [driver css-prefix]
+  (into #{}
+        (map (comp edn/read-string (partial eta/get-element-text-el driver)))
+        (eta/query-all driver {:css (str css-prefix " .tag-list .tag")})))
+
 (deftest view-history-test
   (ui-sys/with-system [driver base-url {fix "history.edn"}]
     (let [note-id (-> fix first :notes/id)]
@@ -83,15 +104,21 @@
               (testing "displays the 1st version of the note"
                 (is (eta/exists? driver {:css ".history__view .lni-paperclip"}))
                 (is (eta/has-text? driver {:css ".history__view h1"} "Some context"))
-                (is (eta/has-text? driver {:css ".history__view .content p"} "Some body"))
+                (is (eta/has-text? driver {:css ".history__view .content p"} "Some body")))
+
+              (testing "displays the 1st version attachments"
                 (is (false? (eta/exists? driver {:xpath "//*[contains(@class,'history__view')]//label[text()='Attachments:']"})))
-                (is (false? (eta/exists? driver {:css ".history__view ul.attachment-list"})))
-                (is (= #{:foo :bar :baz/quux}
-                       (into #{}
-                             (map (comp edn/read-string (partial eta/get-element-text-el driver)))
-                             (eta/query-all driver {:css ".history__view .tag-list .tag"}))))
-                (ui-utils/click driver {:css ".history__view .panel-heading button.button"})
-                (eta/wait-invisible driver {:css ".modal-container.is-active .modal-item.history__view"})))
+                (is (= #{} (collect-attachments driver ".history__view"))))
+
+              (testing "displays the 1st version todos"
+                (is (eta/exists? driver {:xpath "//*[contains(@class,'history__view')]//label[text()='TODOs:']"}))
+                (is (= {"Do a thing" false} (collect-todos driver ".history__view"))))
+
+              (testing "displays the 1st version tags"
+                (is (= #{:foo :bar :baz/quux} (collect-tags driver ".history__view"))))
+
+              (ui-utils/click driver {:css ".history__view .panel-heading button.button"})
+              (eta/wait-invisible driver {:css ".modal-container.is-active .modal-item.history__view"}))
 
             (testing "and when showing version 4"
               (ui-utils/click driver {:xpath "(//button[contains(@class,'note__history-show')])[4]"})
@@ -99,18 +126,22 @@
               (testing "displays the 4th version of the note"
                 (is (false? (eta/exists? driver {:css ".history__view .lni-paperclip"})))
                 (is (eta/has-text? driver {:css ".history__view h1"} "Some context"))
-                (is (eta/has-text? driver {:css ".history__view .content p"} "Some edited body goes here"))
+                (is (eta/has-text? driver {:css ".history__view .content p"} "Some edited body goes here")))
+              (testing "displays the 4th version attachments"
                 (is (eta/exists? driver {:xpath "//*[contains(@class,'history__view')]//label[text()='Attachments:']"}))
-                (is (= #{"some-pdf.pdf" "sample.txt" "image.jpg"}
-                       (into #{}
-                             (map (partial eta/get-element-text-el driver))
-                             (eta/query-all driver {:css ".history__view ul.attachment-list li"}))))
-                (is (= #{:foo :baz/quux}
-                       (into #{}
-                             (map (comp edn/read-string (partial eta/get-element-text-el driver)))
-                             (eta/query-all driver {:css ".history__view .tag-list .tag"}))))
-                (ui-utils/click driver {:css ".history__view .panel-heading button.button"})
-                (eta/wait-invisible driver {:css ".modal-container.is-active .modal-item.history__view"})))
+                (is (= #{"some-pdf.pdf" "sample.txt" "image.jpg"} (collect-attachments driver ".history__view"))))
+
+              (testing "displays the 4th version todos"
+                (is (eta/exists? driver {:xpath "//*[contains(@class,'history__view')]//label[text()='TODOs:']"}))
+                (is (= {"Did a thing"      true
+                        "Do another thing" false}
+                       (collect-todos driver ".history__view"))))
+
+              (testing "displays the 4th version tags"
+                (is (= #{:foo :baz/quux} (collect-tags driver ".history__view"))))
+
+              (ui-utils/click driver {:css ".history__view .panel-heading button.button"})
+              (eta/wait-invisible driver {:css ".modal-container.is-active .modal-item.history__view"}))
 
             (testing "and when showing version 6"
               (ui-utils/click driver {:xpath "(//button[contains(@class,'note__history-show')])[6]"})
@@ -118,15 +149,20 @@
               (testing "displays the 6th version of the note"
                 (is (false? (eta/exists? driver {:css ".history__view .lni-paperclip"})))
                 (is (eta/has-text? driver {:css ".history__view h1"} "Some new context"))
-                (is (eta/has-text? driver {:css ".history__view .content p"} "Some completely different body"))
+                (is (eta/has-text? driver {:css ".history__view .content p"} "Some completely different body")))
+
+              (testing "displays the 6th version attachments"
                 (is (eta/exists? driver {:xpath "//*[contains(@class,'history__view')]//label[text()='Attachments:']"}))
-                (is (= #{"sample.txt" "some other name"}
-                       (into #{}
-                             (map (partial eta/get-element-text-el driver))
-                             (eta/query-all driver {:css ".history__view ul.attachment-list li"}))))
-                (is (= #{:foo :other/tag}
-                       (into #{}
-                             (map (comp edn/read-string (partial eta/get-element-text-el driver)))
-                             (eta/query-all driver {:css ".history__view .tag-list .tag"}))))
-                (ui-utils/click driver {:css ".history__view .panel-heading button.button"})
-                (eta/wait-invisible driver {:css ".modal-container.is-active .modal-item.history__view"})))))))))
+                (is (= #{"sample.txt" "some other name"} (collect-attachments driver ".history__view"))))
+
+              (testing "displays the 6th version todos"
+                (is (eta/exists? driver {:xpath "//*[contains(@class,'history__view')]//label[text()='TODOs:']"}))
+                (is (= {"Did a thing"               true
+                        "Do some third thing still" false}
+                       (collect-todos driver ".history__view"))))
+
+              (testing "displays the 6th version tags"
+                (is (= #{:foo :other/tag} (collect-tags driver ".history__view"))))
+
+              (ui-utils/click driver {:css ".history__view .panel-heading button.button"})
+              (eta/wait-invisible driver {:css ".modal-container.is-active .modal-item.history__view"}))))))))

--- a/test/src/brainard/test/ui/notes/history_test.clj
+++ b/test/src/brainard/test/ui/notes/history_test.clj
@@ -1,0 +1,129 @@
+(ns brainard.test.ui.notes.history-test
+  (:require
+    [brainard.infra.utils.edn :as edn]
+    [brainard.test.ui-system :as ui-sys]
+    [brainard.test.ui.utils :as ui-utils]
+    [clojure.string :as string]
+    [clojure.test :refer [deftest is testing]]
+    [etaoin.api :as eta]))
+
+;; fix todos
+;; 404 on /history for unknown note
+
+(deftest view-history-test
+  (ui-sys/with-system [driver base-url {fix "history.edn"}]
+    (let [note-id (-> fix first :notes/id)]
+      (testing "when visiting the note page"
+        (eta/go driver (str base-url "/notes/" note-id))
+        (eta/wait-visible driver {:css "h1.layout--space-after"})
+
+        (testing "and when viewing the note history"
+          (ui-utils/click driver {:css "button.note__history-button"})
+          (eta/wait-visible driver {:css ".modal-container.is-active .modal-item.history__modal"})
+          (eta/screenshot driver "foo.png")
+          (let [[ver-1 ver-2 ver-3 ver-4 ver-5 ver-6]
+                (for [li (eta/query-all driver {:css "ul.note-history > li"})]
+                  (-> (str "\t" (eta/get-element-text-el driver li))
+                      (string/replace #"\s+" " ")))]
+
+            (testing "displays version 1 changes"
+              (is (string/includes? ver-1 "Topic added Some context"))
+              (is (string/includes? ver-1 "Pin added true"))
+              (is (string/includes? ver-1 "Body added Some body"))
+              (is (string/includes? ver-1 "Tags added :bar, :baz/quux, :foo")))
+
+            (testing "displays version 2 changes"
+              (is (string/includes? ver-2 "Body changed Some body to Some edited body goes here"))
+              (is (string/includes? ver-2 "Tags removed :bar")))
+
+            (testing "displays version 3 changes"
+              (let [attach-updates (second (string/split ver-3 #"Attachments"))]
+                (is (string/includes? attach-updates "added image.jpg"))))
+
+            (testing "displays version 4 changes"
+              (is (string/includes? ver-4 "Pin changed true to false")))
+
+            (testing "displays version 5 changes"
+              (let [attach-updates (second (string/split ver-5 #"Attachments"))]
+                (is (string/includes? attach-updates "changed image.jpg to some other name"))))
+
+            (testing "displays version 6 changes"
+              (let [attach-updates (second (string/split ver-6 #"Attachments"))]
+                (is (string/includes? ver-6 "Topic changed Some context to Some new context"))
+                (is (string/includes? ver-6 "Body changed Some edited body goes here to Some completely different body"))
+                (is (string/includes? ver-6 "Tags added :other/tag removed :baz/quux"))
+                (is (string/includes? attach-updates "removed some-pdf.pdf"))
+                (is (not (string/includes? attach-updates "changed image.jpg to some other name")))))
+
+            (testing "and when showing version 1"
+              (ui-utils/click driver {:xpath "(//button[contains(@class,'note__history-show')])[1]"})
+              (eta/wait-visible driver {:css ".modal-container.is-active .modal-item.history__view"})
+              (testing "displays the 1st version of the note"
+                (is (eta/exists? driver {:css ".history__view .lni-paperclip"}))
+                (is (eta/has-text? driver {:css ".history__view h1"} "Some context"))
+                (is (eta/has-text? driver {:css ".history__view .content p"} "Some body"))
+                (is (not (eta/exists? driver {:xpath "//*[contains(@class,'history__view')]//label[text()='Attachments:']"})))
+                (is (not (eta/exists? driver {:css ".history__view ul.attachment-list li"})))
+                (is (= #{:foo :bar :baz/quux}
+                       (into #{}
+                             (map (comp edn/read-string (partial eta/get-element-text-el driver)))
+                             (eta/query-all driver {:css ".history__view .tag-list .tag"}))))
+                (ui-utils/click driver {:css ".history__view .panel-heading button.button"})
+                (eta/wait-invisible driver {:css ".modal-container.is-active .modal-item.history__view"})))
+
+            (testing "and when showing version 2"
+              (ui-utils/click driver {:xpath "(//button[contains(@class,'note__history-show')])[2]"})
+              (eta/wait-visible driver {:css ".modal-container.is-active .modal-item.history__view"})
+              (testing "displays the 2nd version of the note"
+                (is (eta/exists? driver {:css ".history__view .lni-paperclip"}))
+                (is (eta/has-text? driver {:css ".history__view h1"} "Some context"))
+                (is (eta/has-text? driver {:css ".history__view .content p"} "Some edited body goes here"))
+                (is (eta/exists? driver {:xpath "//*[contains(@class,'history__view')]//label[text()='Attachments:']"}))
+                (is (= #{"some-pdf.pdf" "sample.txt"}
+                       (into #{}
+                             (map (partial eta/get-element-text-el driver))
+                             (eta/query-all driver {:css ".history__view ul.attachment-list li"}))))
+                (is (= #{:foo :baz/quux}
+                       (into #{}
+                             (map (comp edn/read-string (partial eta/get-element-text-el driver)))
+                             (eta/query-all driver {:css ".history__view .tag-list .tag"}))))
+                (ui-utils/click driver {:css ".history__view .panel-heading button.button"})
+                (eta/wait-invisible driver {:css ".modal-container.is-active .modal-item.history__view"})))
+
+            (testing "and when showing version 5"
+              (ui-utils/click driver {:xpath "(//button[contains(@class,'note__history-show')])[5]"})
+              (eta/wait-visible driver {:css ".modal-container.is-active .modal-item.history__view"})
+              (testing "displays the 5th version of the note"
+                (is (not (eta/exists? driver {:css ".history__view .lni-paperclip"})))
+                (is (eta/has-text? driver {:css ".history__view h1"} "Some context"))
+                (is (eta/has-text? driver {:css ".history__view .content p"} "Some edited body goes here"))
+                (is (eta/exists? driver {:xpath "//*[contains(@class,'history__view')]//label[text()='Attachments:']"}))
+                (is (= #{"some-pdf.pdf" "sample.txt" "some other name"}
+                       (into #{}
+                             (map (partial eta/get-element-text-el driver))
+                             (eta/query-all driver {:css ".history__view ul.attachment-list li"}))))
+                (is (= #{:foo :baz/quux}
+                       (into #{}
+                             (map (comp edn/read-string (partial eta/get-element-text-el driver)))
+                             (eta/query-all driver {:css ".history__view .tag-list .tag"}))))
+                (ui-utils/click driver {:css ".history__view .panel-heading button.button"})
+                (eta/wait-invisible driver {:css ".modal-container.is-active .modal-item.history__view"})))
+
+            (testing "and when showing version 6"
+              (ui-utils/click driver {:xpath "(//button[contains(@class,'note__history-show')])[6]"})
+              (eta/wait-visible driver {:css ".modal-container.is-active .modal-item.history__view"})
+              (testing "displays the 6th version of the note"
+                (is (not (eta/exists? driver {:css ".history__view .lni-paperclip"})))
+                (is (eta/has-text? driver {:css ".history__view h1"} "Some new context"))
+                (is (eta/has-text? driver {:css ".history__view .content p"} "Some completely different body"))
+                (is (eta/exists? driver {:xpath "//*[contains(@class,'history__view')]//label[text()='Attachments:']"}))
+                (is (= #{"sample.txt" "some other name"}
+                       (into #{}
+                             (map (partial eta/get-element-text-el driver))
+                             (eta/query-all driver {:css ".history__view ul.attachment-list li"}))))
+                (is (= #{:foo :other/tag}
+                       (into #{}
+                             (map (comp edn/read-string (partial eta/get-element-text-el driver)))
+                             (eta/query-all driver {:css ".history__view .tag-list .tag"}))))
+                (ui-utils/click driver {:css ".history__view .panel-heading button.button"})
+                (eta/wait-invisible driver {:css ".modal-container.is-active .modal-item.history__view"})))))))))

--- a/test/src/brainard/test/ui/notes/history_test.clj
+++ b/test/src/brainard/test/ui/notes/history_test.clj
@@ -17,40 +17,65 @@
         (testing "and when viewing the note history"
           (ui-utils/click driver {:css "button.note__history-button"})
           (eta/wait-visible driver {:css ".modal-container.is-active .modal-item.history__modal"})
-          (eta/screenshot driver "foo.png")
           (let [[ver-1 ver-2 ver-3 ver-4 ver-5 ver-6]
                 (for [li (eta/query-all driver {:css "ul.note-history > li"})]
                   (-> (eta/get-element-text-el driver li)
                       (string/replace #"\s+" " ")))]
 
-            (testing "displays version 1 changes"
-              (is (string/includes? ver-1 "Topic added Some context"))
-              (is (string/includes? ver-1 "Pin added true"))
-              (is (string/includes? ver-1 "Body added Some body"))
-              (is (string/includes? ver-1 "Tags added :bar, :baz/quux, :foo")))
+            (testing "summarizes initial version"
+              (let [todo-updates (second (string/split ver-1 #"Todos"))]
+                (is (string/includes? ver-1 "Topic added Some context"))
+                (is (string/includes? ver-1 "Pin added true"))
+                (is (string/includes? ver-1 "Body added Some body"))
+                (is (string/includes? ver-1 "Tags added :bar, :baz/quux, :foo"))
+                (is (false? (string/includes? ver-1 "Attachments")))
+                (is (string/includes? todo-updates "added Do a thing marked incomplete"))))
 
-            (testing "displays version 2 changes"
-              (is (string/includes? ver-2 "Body changed Some body to Some edited body goes here"))
-              (is (string/includes? ver-2 "Tags removed :bar")))
+            (testing "summarizes version 2 changes"
+              (let [attach-updates (second (string/split ver-2 #"Attachments"))]
+                (is (string/includes? ver-2 "Body changed Some body to Some edited body goes here"))
+                (is (string/includes? ver-2 "Tags removed :bar"))
+                (is (string/includes? attach-updates "added some-pdf.pdf"))
+                (is (string/includes? attach-updates "added sample.txt"))
+                (is (false? (string/includes? ver-2 "Todos")))))
 
-            (testing "displays version 3 changes"
-              (let [attach-updates (second (string/split ver-3 #"Attachments"))]
-                (is (string/includes? attach-updates "added image.jpg"))))
+            (testing "summarizes version 3 changes"
+              (let [attach-updates (second (string/split ver-3 #"Attachments"))
+                    todo-updates (second (string/split ver-3 #"Todos"))]
+                (is (string/includes? attach-updates "added image.jpg"))
+                (is (false? (string/includes? attach-updates "some-pdf.pdf")))
+                (is (false? (string/includes? attach-updates "sample.txt")))
+                (is (string/includes? todo-updates "added Do another thing marked incomplete"))
+                (is (false? (string/includes? todo-updates "Do a thing")))))
 
-            (testing "displays version 4 changes"
-              (is (string/includes? ver-4 "Pin changed true to false")))
+            (testing "summarizes version 4 changes"
+              (let [todo-updates (second (string/split ver-4 #"Todos"))]
+                (is (string/includes? ver-4 "Pin changed true to false"))
+                (is (false? (string/includes? ver-4 "Attachments")))
+                (is (string/includes? todo-updates "changed Do a thing to Did a thing marked complete"))))
 
-            (testing "displays version 5 changes"
-              (let [attach-updates (second (string/split ver-5 #"Attachments"))]
-                (is (string/includes? attach-updates "changed image.jpg to some other name"))))
+            (testing "summarizes version 5 changes"
+              (let [attach-updates (second (string/split ver-5 #"Attachments"))
+                    todo-updates (second (string/split ver-5 #"Todos"))]
+                (is (string/includes? attach-updates "changed image.jpg to some other name"))
+                (is (false? (string/includes? todo-updates "Do a thing")))
+                (is (false? (string/includes? todo-updates "Did a thing")))
+                (is (string/includes? todo-updates "Do another thing marked complete"))
+                (is (string/includes? todo-updates "added Do some third thing marked incomplete"))))
 
-            (testing "displays version 6 changes"
-              (let [attach-updates (second (string/split ver-6 #"Attachments"))]
+            (testing "summarizes version 6 changes"
+              (let [attach-updates (second (string/split ver-6 #"Attachments"))
+                    todo-updates (second (string/split ver-6 #"Todos"))]
                 (is (string/includes? ver-6 "Topic changed Some context to Some new context"))
                 (is (string/includes? ver-6 "Body changed Some edited body goes here to Some completely different body"))
                 (is (string/includes? ver-6 "Tags added :other/tag removed :baz/quux"))
                 (is (string/includes? attach-updates "removed some-pdf.pdf"))
-                (is (not (string/includes? attach-updates "changed image.jpg to some other name")))))
+                (is (false? (string/includes? attach-updates "image.jpg")))
+                (is (false? (string/includes? attach-updates "sample.txt")))
+                (is (false? (string/includes? attach-updates "some other name")))
+                (is (string/includes? todo-updates "removed Do another thing"))
+                (is (string/includes? todo-updates "changed Do some third thing to Do some third thing still"))
+                (is (false? (string/includes? todo-updates "complete")))))
 
             (testing "and when showing version 1"
               (ui-utils/click driver {:xpath "(//button[contains(@class,'note__history-show')])[1]"})
@@ -59,8 +84,8 @@
                 (is (eta/exists? driver {:css ".history__view .lni-paperclip"}))
                 (is (eta/has-text? driver {:css ".history__view h1"} "Some context"))
                 (is (eta/has-text? driver {:css ".history__view .content p"} "Some body"))
-                (is (not (eta/exists? driver {:xpath "//*[contains(@class,'history__view')]//label[text()='Attachments:']"})))
-                (is (not (eta/exists? driver {:css ".history__view ul.attachment-list"})))
+                (is (false? (eta/exists? driver {:xpath "//*[contains(@class,'history__view')]//label[text()='Attachments:']"})))
+                (is (false? (eta/exists? driver {:css ".history__view ul.attachment-list"})))
                 (is (= #{:foo :bar :baz/quux}
                        (into #{}
                              (map (comp edn/read-string (partial eta/get-element-text-el driver)))
@@ -68,34 +93,15 @@
                 (ui-utils/click driver {:css ".history__view .panel-heading button.button"})
                 (eta/wait-invisible driver {:css ".modal-container.is-active .modal-item.history__view"})))
 
-            (testing "and when showing version 2"
-              (ui-utils/click driver {:xpath "(//button[contains(@class,'note__history-show')])[2]"})
+            (testing "and when showing version 4"
+              (ui-utils/click driver {:xpath "(//button[contains(@class,'note__history-show')])[4]"})
               (eta/wait-visible driver {:css ".modal-container.is-active .modal-item.history__view"})
-              (testing "displays the 2nd version of the note"
-                (is (eta/exists? driver {:css ".history__view .lni-paperclip"}))
+              (testing "displays the 4th version of the note"
+                (is (false? (eta/exists? driver {:css ".history__view .lni-paperclip"})))
                 (is (eta/has-text? driver {:css ".history__view h1"} "Some context"))
                 (is (eta/has-text? driver {:css ".history__view .content p"} "Some edited body goes here"))
                 (is (eta/exists? driver {:xpath "//*[contains(@class,'history__view')]//label[text()='Attachments:']"}))
-                (is (= #{"some-pdf.pdf" "sample.txt"}
-                       (into #{}
-                             (map (partial eta/get-element-text-el driver))
-                             (eta/query-all driver {:css ".history__view ul.attachment-list li"}))))
-                (is (= #{:foo :baz/quux}
-                       (into #{}
-                             (map (comp edn/read-string (partial eta/get-element-text-el driver)))
-                             (eta/query-all driver {:css ".history__view .tag-list .tag"}))))
-                (ui-utils/click driver {:css ".history__view .panel-heading button.button"})
-                (eta/wait-invisible driver {:css ".modal-container.is-active .modal-item.history__view"})))
-
-            (testing "and when showing version 5"
-              (ui-utils/click driver {:xpath "(//button[contains(@class,'note__history-show')])[5]"})
-              (eta/wait-visible driver {:css ".modal-container.is-active .modal-item.history__view"})
-              (testing "displays the 5th version of the note"
-                (is (not (eta/exists? driver {:css ".history__view .lni-paperclip"})))
-                (is (eta/has-text? driver {:css ".history__view h1"} "Some context"))
-                (is (eta/has-text? driver {:css ".history__view .content p"} "Some edited body goes here"))
-                (is (eta/exists? driver {:xpath "//*[contains(@class,'history__view')]//label[text()='Attachments:']"}))
-                (is (= #{"some-pdf.pdf" "sample.txt" "some other name"}
+                (is (= #{"some-pdf.pdf" "sample.txt" "image.jpg"}
                        (into #{}
                              (map (partial eta/get-element-text-el driver))
                              (eta/query-all driver {:css ".history__view ul.attachment-list li"}))))
@@ -110,7 +116,7 @@
               (ui-utils/click driver {:xpath "(//button[contains(@class,'note__history-show')])[6]"})
               (eta/wait-visible driver {:css ".modal-container.is-active .modal-item.history__view"})
               (testing "displays the 6th version of the note"
-                (is (not (eta/exists? driver {:css ".history__view .lni-paperclip"})))
+                (is (false? (eta/exists? driver {:css ".history__view .lni-paperclip"})))
                 (is (eta/has-text? driver {:css ".history__view h1"} "Some new context"))
                 (is (eta/has-text? driver {:css ".history__view .content p"} "Some completely different body"))
                 (is (eta/exists? driver {:xpath "//*[contains(@class,'history__view')]//label[text()='Attachments:']"}))

--- a/test/src/brainard/test/ui/notes/history_test.clj
+++ b/test/src/brainard/test/ui/notes/history_test.clj
@@ -12,23 +12,24 @@
         (map (partial eta/get-element-text-el driver))
         (eta/query-all driver {:css (str css-prefix " ul.attachment-list li")})))
 
-(defn ^:private collect-todos [driver css-prefix]
+(defn ^:private collect-todos [driver {:keys [css-prefix disabled?]}]
   (into {}
         (map (fn [todo]
                (let [txt (eta/get-element-text-el driver todo)
                      chbox (eta/query-from-shadow-root-el driver
                                                           todo
-                                                          {:css "input[type=checkbox]:disabled"})
+                                                          {:css (cond-> "input[type=checkbox]"
+                                                                  disabled? (str ":disabled"))})
                      checked (eta/get-element-attr-el driver chbox "checked")]
                  [txt (some? checked)])))
-        (eta/query-all driver {:css (str css-prefix " .todo-list .todo")})))
+       (eta/query-all driver {:css (str css-prefix " .todo-list .todo")})))
 
 (defn ^:private collect-tags [driver css-prefix]
   (into #{}
         (map (comp edn/read-string (partial eta/get-element-text-el driver)))
         (eta/query-all driver {:css (str css-prefix " .tag-list .tag")})))
 
-(deftest view-history-test
+(deftest view-test
   (ui-sys/with-system [driver base-url {fix "history.edn"}]
     (let [note-id (-> fix first :notes/id)]
       (testing "when visiting the note page"
@@ -112,12 +113,12 @@
 
               (testing "displays the 1st version todos"
                 (is (eta/exists? driver {:xpath "//*[contains(@class,'history__view')]//label[text()='TODOs:']"}))
-                (is (= {"Do a thing" false} (collect-todos driver ".history__view"))))
+                (is (= {"Do a thing" false} (collect-todos driver {:css-prefix ".history__view"}))))
 
               (testing "displays the 1st version tags"
                 (is (= #{:foo :bar :baz/quux} (collect-tags driver ".history__view"))))
 
-              (ui-utils/click driver {:css ".history__view .panel-heading button.button"})
+              (ui-utils/click driver {:css ".history__view .panel-heading .lni-close"})
               (eta/wait-invisible driver {:css ".modal-container.is-active .modal-item.history__view"}))
 
             (testing "and when showing version 4"
@@ -135,12 +136,12 @@
                 (is (eta/exists? driver {:xpath "//*[contains(@class,'history__view')]//label[text()='TODOs:']"}))
                 (is (= {"Did a thing"      true
                         "Do another thing" false}
-                       (collect-todos driver ".history__view"))))
+                       (collect-todos driver {:css-prefix ".history__view"}))))
 
               (testing "displays the 4th version tags"
                 (is (= #{:foo :baz/quux} (collect-tags driver ".history__view"))))
 
-              (ui-utils/click driver {:css ".history__view .panel-heading button.button"})
+              (ui-utils/click driver {:css ".history__view .panel-heading .lni-close"})
               (eta/wait-invisible driver {:css ".modal-container.is-active .modal-item.history__view"}))
 
             (testing "and when showing version 6"
@@ -159,10 +160,134 @@
                 (is (eta/exists? driver {:xpath "//*[contains(@class,'history__view')]//label[text()='TODOs:']"}))
                 (is (= {"Did a thing"               true
                         "Do some third thing still" false}
-                       (collect-todos driver ".history__view"))))
+                       (collect-todos driver {:css-prefix ".history__view"}))))
 
               (testing "displays the 6th version tags"
                 (is (= #{:foo :other/tag} (collect-tags driver ".history__view"))))
 
-              (ui-utils/click driver {:css ".history__view .panel-heading button.button"})
+              (ui-utils/click driver {:css ".history__view .panel-heading .lni-close"})
               (eta/wait-invisible driver {:css ".modal-container.is-active .modal-item.history__view"}))))))))
+
+(deftest reinstate-test
+  (ui-sys/with-system [driver base-url {fix "history.edn"}]
+    (let [note-id (-> fix first :notes/id)]
+      (testing "when visiting the note page"
+        (eta/go driver (str base-url "/notes/" note-id))
+        (eta/wait-visible driver {:css "h1.layout--space-after"})
+
+        (testing "and when viewing the note history"
+          (ui-utils/click driver {:css "button.note__history-button"})
+          (eta/wait-visible driver {:css ".modal-container.is-active .modal-item.history__modal"})
+
+          (testing "and when showing version 6"
+            (ui-utils/click driver {:xpath "(//button[contains(@class,'note__history-show')])[6]"})
+            (eta/wait-visible driver {:css ".modal-container.is-active .modal-item.history__view"})
+
+            (testing "cannot reinstate the current note version"
+              (is (not (eta/exists? driver {:css ".history__view button.note__history-reinstate"}))))
+
+            (ui-utils/click driver {:css ".history__view .panel-heading .lni-close"})
+            (eta/wait-invisible driver {:css ".modal-container.is-active .modal-item.history__view"}))
+
+          (testing "and when showing version 3"
+            (ui-utils/click driver {:xpath "(//button[contains(@class,'note__history-show')])[3]"})
+            (eta/wait-visible driver {:css ".modal-container.is-active .modal-item.history__view"})
+            (testing "displays the 3rd version of the note"
+              (is (eta/exists? driver {:css ".history__view .lni-paperclip"}))
+              (is (eta/has-text? driver {:css ".history__view h1"} "Some context"))
+              (is (eta/has-text? driver {:css ".history__view .content p"} "Some edited body goes here")))
+
+            (testing "displays the 3rd version attachments"
+              (is (eta/exists? driver {:xpath "//*[contains(@class,'history__view')]//label[text()='Attachments:']"}))
+              (is (= #{"image.jpg" "sample.txt" "some-pdf.pdf"} (collect-attachments driver ".history__view"))))
+
+            (testing "displays the 3rd version todos"
+              (is (eta/exists? driver {:xpath "//*[contains(@class,'history__view')]//label[text()='TODOs:']"}))
+              (is (= {"Do a thing"       false
+                      "Do another thing" false}
+                     (collect-todos driver {:css-prefix ".history__view"}))))
+
+            (testing "displays the 3rd version tags"
+              (is (= #{:foo :baz/quux} (collect-tags driver ".history__view"))))
+
+            (testing "and when reinstating the note version"
+              (ui-utils/click driver {:css ".history__view button.note__history-reinstate"})
+              (eta/wait-invisible driver {:css ".modal-container.is-active .modal-item.history__view"})
+              (ui-utils/click driver {:css ".history__modal .lni-close"})
+              (eta/wait-invisible driver {:css ".modal-container.is-active"})
+              (eta/wait-visible driver {:xpath "//h1[.='Some context']"})
+
+              (testing "reinstates the 3rd version of the note"
+                (is (eta/exists? driver {:css "button.is-info i.lni-paperclip"}))
+                (is (eta/exists? driver {:xpath "//h1[.='Some context']"}))
+                (is (eta/has-text? driver {:css ".content p"} "Some edited body goes here")))
+
+              (testing "reinstates the 3rd version attachments"
+                (is (eta/exists? driver {:xpath "//label[text()='Attachments:']"}))
+                (is (= #{"image.jpg" "sample.txt" "some-pdf.pdf"} (collect-attachments driver ""))))
+
+              (testing "reinstates the 3rd version todos"
+                (is (eta/exists? driver {:xpath "//label[text()='TODOs:']"}))
+                (is (= {"Do a thing"       false
+                        "Do another thing" false}
+                       (collect-todos driver {:disabled? false}))))
+
+              (testing "reinstates the 3rd version tags"
+                (is (= #{:foo :baz/quux} (collect-tags driver ""))))
+
+              (testing "and when viewing the note history"
+                (ui-utils/click driver {:css "button.note__history-button"})
+                (eta/wait-visible driver {:css ".modal-container.is-active .modal-item.history__modal"})
+
+                (testing "and when showing version 7"
+                  (ui-utils/click driver {:xpath "(//button[contains(@class,'note__history-show')])[7]"})
+                  (eta/wait-visible driver {:css ".modal-container.is-active .modal-item.history__view"})
+                  (testing "displays the 7th version of the note"
+                    (is (eta/exists? driver {:css ".history__view .lni-paperclip"}))
+                    (is (eta/has-text? driver {:css ".history__view h1"} "Some context"))
+                    (is (eta/has-text? driver {:css ".history__view .content p"} "Some edited body goes here")))
+
+                  (testing "displays the 7th version attachments"
+                    (is (eta/exists? driver {:xpath "//*[contains(@class,'history__view')]//label[text()='Attachments:']"}))
+                    (is (= #{"image.jpg" "sample.txt" "some-pdf.pdf"} (collect-attachments driver ".history__view"))))
+
+                  (testing "displays the 7th version todos"
+                    (is (eta/exists? driver {:xpath "//*[contains(@class,'history__view')]//label[text()='TODOs:']"}))
+                    (is (= {"Do a thing"       false
+                            "Do another thing" false}
+                           (collect-todos driver {:css-prefix ".history__view"}))))
+
+                  (testing "displays the 7th version tags"
+                    (is (= #{:foo :baz/quux} (collect-tags driver ".history__view"))))
+
+                  (ui-utils/click driver {:css ".history__view .panel-heading .lni-close"})
+                  (eta/wait-invisible driver {:css ".modal-container.is-active .modal-item.history__view"}))
+
+                (testing "and when showing version 6"
+                  (ui-utils/click driver {:xpath "(//button[contains(@class,'note__history-show')])[6]"})
+                  (eta/wait-visible driver {:css ".modal-container.is-active .modal-item.history__view"})
+
+                  (testing "and when reinstating the note version"
+                    (ui-utils/click driver {:css ".history__view button.note__history-reinstate"})
+                    (eta/wait-invisible driver {:css ".modal-container.is-active .modal-item.history__view"})
+                    (ui-utils/click driver {:css ".history__modal .lni-close"})
+                    (eta/wait-invisible driver {:css ".modal-container.is-active"})
+                    (eta/wait-visible driver {:xpath "//h1[.='Some new context']"})
+
+                    (testing "reinstates the 6th version of the note"
+                      (is (eta/exists? driver {:css "button:not(.is-info) i.lni-paperclip"}))
+                      (is (eta/exists? driver {:xpath "//h1[.='Some new context']"}))
+                      (is (eta/has-text? driver {:css ".content p"} "Some completely different body")))
+
+                    (testing "reinstates the 6th version attachments"
+                      (is (eta/exists? driver {:xpath "//label[text()='Attachments:']"}))
+                      (is (= #{"sample.txt" "some other name"} (collect-attachments driver ""))))
+
+                    (testing "reinstates the 6th version todos"
+                      (is (eta/exists? driver {:xpath "//label[text()='TODOs:']"}))
+                      (is (= {"Did a thing"       true
+                              "Do some third thing still" false}
+                             (collect-todos driver {:disabled? false}))))
+
+                    (testing "reinstates the 6th version tags"
+                      (is (= #{:foo :other/tag} (collect-tags driver ""))))))))))))))

--- a/test/src/brainard/test/ui/notes/todos_test.clj
+++ b/test/src/brainard/test/ui/notes/todos_test.clj
@@ -54,7 +54,9 @@
             (eta/wait-visible driver {:css ".modal-container.is-active .note-edit__todo"})
 
             (testing "opens the edit todo modal"
-              (is (eta/has-text? driver {:css ".modal-container.is-active .note-edit__todo"} "Edit your TODO")))
+              (is (eta/has-text? driver
+                                 {:css ".modal-container.is-active .note-edit__todo"}
+                                 "Edit your TODO")))
 
             (testing "and when modifying and saving the todo"
               (ui-utils/fill-field! driver "TODO" "Updated todo text")
@@ -62,7 +64,9 @@
               (eta/wait-invisible driver {:css ".modal-container.is-active .note-edit__todo"})
 
               (testing "closes the todo modal and displays the updated todo"
-                (is (eta/has-text? driver {:css ".modal-container.is-active ul.todo-list"} "Updated todo text"))))))))))
+                (is (eta/has-text? driver
+                                   {:css ".modal-container.is-active ul.todo-list"}
+                                   "Updated todo text"))))))))))
 
 (deftest complete-todo-test
   (ui-sys/with-system [driver base-url {fix "base.edn"}]

--- a/test/src/brainard/test/ui_system.clj
+++ b/test/src/brainard/test/ui_system.clj
@@ -5,6 +5,16 @@
     [brainard.test.ui.utils :as ui-utils]
     [etaoin.api :as eta]))
 
+(defn transact-multi! [db data]
+  (if (map? data)
+    (->> data
+         (sort-by key)
+         (into [] (mapcat (fn [[_ tx-data]]
+                            (ds/transact! db tx-data)
+                            tx-data))))
+    (doto data
+      (->> (ds/transact! db)))))
+
 (defmacro with-system [[driver-binding base-url-binding bnds] & body]
   (let [db-sym (gensym "db")]
     `(tsys/with-system [{port# :cfg/server-port ~db-sym :brainard/IDBConn}
@@ -22,7 +32,7 @@
                      token [sym `(cond-> ~seed
                                    (string? ~seed) (->> (str "seed/")
                                                         ui-utils/edn-fixture)
-                                   true (doto (->> (ds/transact! ~db-sym))))]]
+                                   true (->> (transact-multi! ~db-sym)))]]
                  token)]
          (try
            ~@body


### PR DESCRIPTION
- adds todos to note history query
- refactors history reconstruction, adding support for todos and fixing bugs
- displays todo changes in history view
- updates todos when reinstating note version
- adds `brainard.test.ui.notes.history-test`